### PR TITLE
Reposition navigation bar in layout

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -130,8 +130,11 @@ header {
   border: 1px solid var(--color-border);
 }
 
-section {
+main {
   grid-area: main;
+}
+
+section {
   padding: var(--space-lg);
   background: var(--color-bg);
   border-radius: 8px;


### PR DESCRIPTION
Move `grid-area: main` to the `main` element to correctly position the navigation bar within the grid layout.

The navigation bar was appearing incorrectly because it was a direct child of the `main` element, while the `grid-area: main` property was applied to the nested `section` element. Moving `grid-area: main` to the `main` element ensures that all content within `main`, including the navigation bar, is correctly placed in the right column of the grid.