### PR TITLE
Remove drop shadow borders for simplicity

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -125,9 +125,6 @@ header {
   top: var(--space-md);
   background: var(--color-bg);
   padding: var(--space-lg);
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  border: 1px solid var(--color-border);
 }
 
 main {
@@ -137,9 +134,6 @@ main {
 section {
   padding: var(--space-lg);
   background: var(--color-bg);
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  border: 1px solid var(--color-border);
 }
 
 /* Navigation Improvements */
@@ -390,13 +384,6 @@ th {
 /* Removed outdated gradient styles */
 
 /* Enhanced hover states */
-header:hover {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-}
-
-section:hover {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-}
 
 /* Improved spacing for content sections */
 section > h1:first-child {


### PR DESCRIPTION
Remove drop shadow and border styles from main content areas for a simpler, streamlined look.