### PR TITLE
Disable iOS phone number auto-detection on research page

### DIFF
--- a/research.html
+++ b/research.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="stylesheets/styles.css">
     <link rel="stylesheet" href="stylesheets/github-light.css">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+    <meta name="format-detection" content="telephone=no">
     <!--[if lt IE 9]>
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->


### PR DESCRIPTION
iOS Safari was interpreting page ranges (e.g., "pp. 1557–1626") as
clickable phone numbers. Adding format-detection meta tag prevents this.

https://claude.ai/code/session_01MVisPNayTSW4jYi9P2wQMz

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single, non-functional HTML metadata change limited to client-side rendering/behavior on mobile browsers.
> 
> **Overview**
> Adds `<meta name="format-detection" content="telephone=no">` to `research.html` to prevent iOS Safari from auto-linking page ranges and similar numeric text as phone numbers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4905b97e35a53e07acaa106b9181cfc1ed4dec86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->